### PR TITLE
Add postBuild and requirements.txt file for binder

### DIFF
--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,9 @@
+jupyter contrib nbextension install --user
+jupyter nbextension enable --py widgetsnbextension
+jupyter nbextension enable python-markdown/main
+
+# Notebooks w/ extensions that auto-run code must be "trusted" to work the first time
+jupyter trust index.ipynb
+jupyter trust 01-ElasticBarLinearFEM.ipynb
+jupyter trust 02-ShapeFunctions.ipynb
+jupyter trust 03-TimeDependentProblems.ipynb

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 jupyter
+numpy
+matplotlib
+jupyter_contrib_nbextensions


### PR DESCRIPTION
Added a postBuild file to run Jupyter notebook in mybinder.org, without this file running notebook on binder fails as `numpy` is not installed. 

Pre-requisites are specified using a `requirements.txt` file to install the extensions, then a `postBuild` file is used to enable them.

Documentation for the same is here: https://mybinder.readthedocs.io/en/latest/using.html
and https://github.com/binder-examples/jupyter-extension

